### PR TITLE
Remove redundancy that leads to null output in main.py

### DIFF
--- a/model/framework/code/main.py
+++ b/model/framework/code/main.py
@@ -17,23 +17,6 @@ tmp_dir = tempfile.mkdtemp("eos-")
 input_file = os.path.abspath(sys.argv[1])
 output_file = os.path.abspath(sys.argv[2])
 
-smiles = []
-with open(input_file, "r") as f:
-    reader = csv.reader(f)
-    next(reader)
-    for r in reader:
-        smiles += [r[0]]
-
-mols = []
-for i, smi in enumerate(smiles):
-    mol = Chem.MolFromSmiles(smi)
-    mol = standardise.run(mol)
-    if mol is not None:
-        smi = Chem.MolToSmiles(mol)
-        mol = Chem.MolFromSmiles(smi)
-        mol.SetProp("MoleculeIdentifier", "id-{0}".format(i))
-    
-    mols += [mol]
 
 # load saved model
 mdl_ckpt = os.path.join(root, "..", "..", "checkpoints", "model.joblib")


### PR DESCRIPTION
Removing this redundancy code (a remnant from the conversion to sdf files ) in main.py as it makes execution fail for SMILES string that cannot be standardized and results in a Null Output predictions for those instances. I then ran predictions with the previously used datasets, on the updated repo and predictions was gotten for all molecules.

Results without code: [eos30gr_pred.csv](https://github.com/ersilia-os/eos30gr/files/14894388/eos30gr_pred.csv)


Results with code: [eos30gr_output.csv](https://github.com/ersilia-os/eos30gr/files/14894387/eos30gr_output.csv)
 